### PR TITLE
Fixed possible bad color data issue and minor optimization

### DIFF
--- a/src/client/models/annotation.js
+++ b/src/client/models/annotation.js
@@ -31,9 +31,8 @@ export default class Annotation extends THREE.EventDispatcher {
                     let index = 0;
                     for (let i = 0; i < cData.length; i++) {
                         index += cData[i].duration;
-                        if (stripIndex <= index) {
-                            color = cData[i].data;
-                        }
+                        color = cData[i].data;
+                        if (index > stripIndex) break;
                     }
                 }
                 // Build colors array


### PR DESCRIPTION
This should prevent "bad" color data from causing the last color to always be picked (changing index into a `NaN`).

This also saves some iterations (though it doesn't really matter)